### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-container:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kelsoncm/code2pdf/security/code-scanning/1](https://github.com/kelsoncm/code2pdf/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/deploy.yml` at the workflow root so it applies to all jobs (including `build-container`).  
The minimal safe fix, aligned with CodeQL guidance and without changing workflow behavior, is:

- `permissions:`
  - `contents: read`

Place it after the `on:` trigger block and before `jobs:`.  
No imports, methods, or additional definitions are required since this is YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
